### PR TITLE
fix comment-skip value

### DIFF
--- a/powershell-ts-mode.el
+++ b/powershell-ts-mode.el
@@ -428,7 +428,7 @@ And not a class or function parent."
 
   ;; some other non treesitter setup
   (setq-local comment-start "#")
-  (setq-local comment-start-skip "#+\\s*")
+  (setq-local comment-start-skip "#+ *")
   (setq-local electric-indent-chars
               (append "{}():;," electric-indent-chars))
   (setq-local compile-command powershell-ts-compile-command)


### PR DESCRIPTION
Fix this so that `comment-dwim` is working again for comment that's not started from beginning of line.